### PR TITLE
Add Flask app for invoice processing

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,12 @@ from openai import OpenAI
 
 app = Flask(__name__)
 
-client = OpenAI()
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+SCHEMA_DESCRIPTION = (
+    '{"factura": [{"Denumire_Furnizor": str, "Denumire_Material": str, '
+    '"Cantitate": number, "Pret_unitar": number, "Pret_total": number}]}'
+)
 
 @app.route('/')
 def index():
@@ -21,14 +26,24 @@ def upload():
     with pdfplumber.open(pdf_file.stream) as pdf:
         text = "\n".join(page.extract_text() or "" for page in pdf.pages)
 
+    prompt = (
+        "Extrage informațiile despre linii de factură din textul de mai jos "
+        "și răspunde strict în format JSON conform următoarei scheme: "
+        f"{SCHEMA_DESCRIPTION}.\n\n{text}"
+    )
+
     response = client.responses.create(
         model="gpt-4o-mini",
-        input=text,
+        input=prompt,
         response_format={"type": "json_object"},
     )
 
-    result_json = json.loads(response.output_text)
+    try:
+        result_json = json.loads(response.output_text)
+    except json.JSONDecodeError:
+        result_json = {"factura": []}
+
     return render_template('index.html', factura=result_json.get("factura", []))
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', 5000)), debug=False)
+    app.run(host='0.0.0.0', port=int(os.environ.get("PORT", 5000)), debug=False)

--- a/app.py
+++ b/app.py
@@ -1,0 +1,34 @@
+import os
+import json
+import pdfplumber
+from flask import Flask, request, render_template
+from openai import OpenAI
+
+app = Flask(__name__)
+
+client = OpenAI()
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    pdf_file = request.files.get('pdf')
+    if not pdf_file:
+        return "No PDF uploaded", 400
+
+    with pdfplumber.open(pdf_file.stream) as pdf:
+        text = "\n".join(page.extract_text() or "" for page in pdf.pages)
+
+    response = client.responses.create(
+        model="gpt-4o-mini",
+        input=text,
+        response_format={"type": "json_object"},
+    )
+
+    result_json = json.loads(response.output_text)
+    return render_template('index.html', factura=result_json.get("factura", []))
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', 5000)), debug=False)

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: web
+    name: verificare-facturi
+    env: python
+    buildCommand: "pip install -r requirements.txt"
+    startCommand: "gunicorn app:app"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+openai
+pdfplumber
+gunicorn

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Verificare Facturi</title>
+</head>
+<body>
+    <h1>Încarcă PDF</h1>
+    <form action="/upload" method="post" enctype="multipart/form-data">
+        <input type="file" name="pdf" accept="application/pdf" required>
+        <button type="submit">Procesează</button>
+    </form>
+
+    {% if factura %}
+    <h2>Rezultat</h2>
+    <table border="1">
+        <thead>
+            <tr>
+                <th>Denumire Furnizor</th>
+                <th>Denumire Material</th>
+                <th>Cantitate</th>
+                <th>Pret unitar</th>
+                <th>Pret total</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for item in factura %}
+            <tr>
+                <td>{{ item.Denumire_Furnizor }}</td>
+                <td>{{ item.Denumire_Material }}</td>
+                <td>{{ item.Cantitate }}</td>
+                <td>{{ item.Pret_unitar }}</td>
+                <td>{{ item.Pret_total }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask backend to parse PDF invoices, call GPT-4o-mini, and render results
- add HTML upload form and table to display parsed invoice data
- add deployment files and dependencies

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68a6cf044e948331b73c27787e30ae22